### PR TITLE
fix(inputs): make github_token optional

### DIFF
--- a/.github/workflows/example-runs.yml
+++ b/.github/workflows/example-runs.yml
@@ -10,8 +10,6 @@ jobs:
 
       - id: fetch-latest-release
         uses: ./
-        with:
-          github_token: ${{ github.token }}
 
       - name: print out latest release tag
         run: echo "The latest release tag is $TAG"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A tiny GitHub action to fetch the latest GitHub release for a given repository
 
 | Parameter           | Description                                                                                | Required | Default      |
 | ------------------- | ------------------------------------------------------------------------------------------ | -------- | ------------ |
-| `github_token`      | A Github token, usually `${{ github.token }}`.                                             | **Y**    | N/A          |
+| `github_token`      | A Github token, usually `${{ github.token }}`.                                             | N        | `${{ github.token }}`  |
 | `repo_path`         | Provide a "owner/repo" string for fetching from a different repo.                          | N        | The current repo       |
 
 ## Output

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,8 @@ runs:
 inputs:
   github_token:
     description: A Github token for the repo, usually `{{ github.token }}`.
-    required: true
+    required: false
+    default: ${{ github.token }}
   repo_path:
     description: Provide a "owner/repo" string for fetching from a different repo.
     required: false


### PR DESCRIPTION
It is common practice to omit github token for public repositories.

BREAKING CHANGE: set the default value of `github_token` to `${{ github.token }}`.

